### PR TITLE
Aliases and groups

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -70,3 +70,22 @@ Outbound.prototype.group = function(payload, fn){
   .send(payload)
   .end(this.handle(fn));
 };
+
+/**
+* Alias.
+*
+* @param {Alias} alias
+* @param {Function} fn
+* @api private
+*/
+
+Outbound.prototype.alias = function(payload, fn){
+
+  // Outbound v2
+  return this
+  .post('/v2/identify')
+  .set('X-Outbound-Key', this.settings.apiKey)
+  .type('json')
+  .send(payload)
+  .end(this.handle(fn));
+};

--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -68,8 +68,22 @@ exports.group = function(group){
 
   return {
     user_id: group.userId(),
-    attributes: {
-      group: group.traits()
-    }
+    group_id: group.groupId(),
+    group_attributes: group.traits()
   };
 };
+
+/**
+* Map alias.
+*
+* @param {Alias} alias
+* @return {Object}
+* @api private
+*/
+
+exports.alias = function(alias) {
+    return {
+        user_id: group.userId(),
+        previous_id: group.previousId()
+    }
+}

--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -82,8 +82,8 @@ exports.group = function(group){
 */
 
 exports.alias = function(alias) {
-    return {
-        user_id: group.userId(),
-        previous_id: group.previousId()
-    }
+  return {
+    user_id: alias.userId(),
+    previous_id: alias.previousId()
+  }
 }

--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -66,11 +66,16 @@ exports.group = function(group){
 
   // Outbound V2
 
-  return {
+  var body = {
     user_id: group.userId(),
     group_id: group.groupId(),
     group_attributes: group.traits()
   };
+
+  var attrs = body.group_attributes;
+  del(attrs, 'id');
+
+  return body;
 };
 
 /**
@@ -81,7 +86,7 @@ exports.group = function(group){
 * @api private
 */
 
-exports.alias = function(alias) {
+exports.alias = function(alias){
   return {
     user_id: alias.userId(),
     previous_id: alias.previousId()

--- a/test/fixtures/alias-basic.json
+++ b/test/fixtures/alias-basic.json
@@ -1,0 +1,12 @@
+{
+  "input": {
+    "type": "alias",
+    "userId": "user-id",
+    "previousId": "prev-id",
+    "timestamp": "2014"
+  },
+  "output": {
+    "user_id": "user-id",
+    "previous_id": "prev-id"
+  }
+}

--- a/test/fixtures/group-basic.json
+++ b/test/fixtures/group-basic.json
@@ -2,6 +2,7 @@
   "input": {
     "type": "group",
     "userId": "user-id",
+    "groupId": "group-id",
     "timestamp": "2014",
     "traits": {
       "name": "ballers",
@@ -10,11 +11,10 @@
   },
   "output": {
     "user_id": "user-id",
-    "attributes": {
-      "group": {
-        "name": "ballers",
-        "duty": "shot calling"
-      }
+    "group_id": "group-id",
+    "group_attributes": {
+      "name": "ballers",
+      "duty": "shot calling"
     }
   }
 }

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -85,41 +85,40 @@ exports.transaction = function(options){
  * @param {Object} options
  * @return {Track}
  */
-
-exports.track = function (options) {
+exports.track = function(options){
   options = options || {};
   return new facade.Track(merge({
-    userId     : firstId,
-    event      : 'Baked a cake',
-    properties : {
-      layers  : ['chocolate', 'strawberry', 'fudge'],
-      revenue : 19.95,
-      numLayers : 10,
-      fat : 0.02,
-      bacon : '1',
-      date : (new Date()).toISOString(),
-      address : {
-        state : 'CA',
-        zip  : 94107,
-        city : 'San Francisco'
+    userId: firstId,
+    event: 'Baked a cake',
+    properties: {
+      layers: ['chocolate', 'strawberry', 'fudge'],
+      revenue: 19.95,
+      numLayers: 10,
+      fat: 0.02,
+      bacon: '1',
+      date: (new Date()).toISOString(),
+      address: {
+        state: 'CA',
+        zip: 94107,
+        city: 'San Francisco'
       }
     },
-    channel    : 'server',
-    timestamp  : new Date(),
-    options : {
-      traits : {
-        email   : options.email || email,
-        age     : 23,
-        created : new Date(),
-        bad     : null,
-        alsoBad : undefined,
-        address : {
-          state : 'CA',
-          zip  : 94107,
-          city : 'San Francisco'
+    channel: 'server',
+    timestamp: new Date(),
+    options: {
+      traits: {
+        email: options.email || email,
+        age: 23,
+        created: new Date(),
+        bad: null,
+        alsoBad: undefined,
+        address: {
+          state: 'CA',
+          zip: 94107,
+          city: 'San Francisco'
         }
       },
-      ip : '4.184.68.0',
+      ip: '4.184.68.0',
       userAgent: 'Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)'
     }
   }, options));
@@ -131,13 +130,11 @@ exports.track = function (options) {
  * @param {Object} options
  * @return {Track}
  */
-
-
-exports.track.bare = function (options) {
+exports.track.bare = function(options){
   return new facade.Track(merge({
-    userId  : 'aaa',
-    event   : 'Bear tracks',
-    channel : 'server'
+    userId: 'aaa',
+    event: 'Bear tracks',
+    channel: 'server'
   }, options || {}));
 };
 
@@ -147,37 +144,36 @@ exports.track.bare = function (options) {
  * @param {Object} options
  * @return {Identify}
  */
-
-exports.identify = function (options) {
+exports.identify = function(options){
   options = options || {};
   return new facade.Identify(merge({
-    userId : firstId,
-    traits : {
-      fat         : 0.02,
-      firstName   : 'John',
-      'Last Name' : 'Doe',
-      email       : options.email || email,
-      company     : 'Segment.io',
-      city        : 'San Francisco',
-      state       : 'CA',
-      phone       : '5555555555',
-      websites    : [
+    userId: firstId,
+    traits: {
+      fat: 0.02,
+      firstName: 'John',
+      'Last Name': 'Doe',
+      email: options.email || email,
+      company: 'Segment.io',
+      city: 'San Francisco',
+      state: 'CA',
+      phone: '5555555555',
+      websites: [
         'http://calv.info',
         'http://ianstormtaylor.com',
         'http://ivolo.me',
         'http://rein.pk'
       ],
-      bad     : null,
-      alsoBad : undefined,
-      met : (new Date()).toISOString(),
-      created : new Date('1/12/2013'),
+      bad: null,
+      alsoBad: undefined,
+      met: (new Date()).toISOString(),
+      created: new Date('1/12/2013'),
       userAgent: 'Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)'
     },
-    context : {
-      ip : '12.212.12.49'
+    context: {
+      ip: '12.212.12.49'
     },
-    timestamp : new Date(),
-    channel : 'server'
+    timestamp: new Date(),
+    channel: 'server'
   }, options));
 };
 
@@ -261,12 +257,11 @@ exports.group = function(options){
  * @param {Object} options
  * @return {Alias}
  */
-
-exports.alias = function (options) {
+exports.alias = function(options){
   return new facade.Alias(merge({
-    from      : firstId,
-    to        : secondId,
-    channel   : 'server',
-    timestamp : new Date()
+    from: firstId,
+    to: secondId,
+    channel: 'server',
+    timestamp: new Date()
   }, options || {}));
 };

--- a/test/index.js
+++ b/test/index.js
@@ -45,9 +45,7 @@ describe('Outbound', function(){
     });
   });
 
-
   describe('mapper', function(){
-
     describe('track', function(){
       it('should map basic track', function(){
         test.maps('track-basic');
@@ -78,6 +76,11 @@ describe('Outbound', function(){
       });
     });
 
+    describe('alias', function(){
+      it('should map basic alias', function(){
+        test.maps('alias-basic');
+      });
+    });
 
   });
 
@@ -147,6 +150,24 @@ describe('Outbound', function(){
       .set({ apiKey: 'x' })
       .track({ event: 'event' })
       .group({})
+      .error('cannot POST /v2/identify (401)', done);
+    });
+  });
+
+  describe('.alias()', function(){
+    it('should alias successfully', function(done){
+      var json = test.fixture('alias-basic');
+      test
+      .alias(json.input)
+      .sends(json.output)
+      .expects(200, done);
+    });
+
+    it('should error on invalid request', function(done){
+      test
+      .set({ apiKey: 'x' })
+      .track({ event: 'event' })
+      .alias({})
       .error('cannot POST /v2/identify (401)', done);
     });
   });


### PR DESCRIPTION
We're working on adding support for groups and aliases to our API. For groups our `identify` endpoints just takes a `group_id` and `group_attributes` params. For aliases the `identify` endpoint takes a `previous_id` param.

Please let me know if this implemented right.

Please don't merge this yet. We'll won't be releasing these features until later this week. Just wanted to get this out there in case it was wrong so that it can be ready to go when we are ready to deploy.
