### PR TITLE
EPD-315 Fallback on anonymousId

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,10 +1,14 @@
 
+1.4.0 / 2016-12-13
+==================
+
+  * Fallback on anonymousId if userId is missing for `.identify()` calls
+
 1.3.0 / 2016-08-11
 ==================
 
   * page screen timezone implementation into OB
   * add docker, refactor circle
-
 
 1.2.1 / 2015-04-07
 ==================

--- a/lib/index.js
+++ b/lib/index.js
@@ -83,7 +83,7 @@ Outbound.prototype.alias = function(payload, fn){
 /**
  * Page.
  *
- * @apram {Page} payload
+ * @param {Page} payload
  * @param {Function} fn
  * @api private
  */
@@ -99,7 +99,7 @@ Outbound.prototype.page = function(payload, fn){
 /**
  * Screen.
  *
- * @apram {Screen} payload
+ * @param {Screen} payload
  * @param {Function} fn
  * @api private
  */

--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -12,7 +12,7 @@ var del = require('obj-case').del;
 
 exports.identify = function(identify){
   var body = {
-    user_id: identify.userId(),
+    user_id: identify.userId() || identify.anonymousId(),
     attributes: identify.traits(),
     email: identify.email(),
     phone_number: identify.phone(),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "integration-outbound",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "description": "Outbound server-side integration",
   "author": "Segment <friends@segment.com>",

--- a/test/fixtures/identify-anonymous.json
+++ b/test/fixtures/identify-anonymous.json
@@ -1,0 +1,32 @@
+{
+  "input": {
+    "type": "identify",
+    "userId": null,
+    "anonymousId": "gucci mane",
+    "traits": {
+      "avatar": "https://some.url/avatar.jpg",
+      "country": "some-country",
+      "name": "John Doe",
+      "gender": "male",
+      "email": "jd@example.com",
+      "phone": "55555",
+      "city": "some-city",
+      "age": 3e3
+    }
+  },
+  "output": {
+    "user_id": "gucci mane",
+    "attributes": {
+      "avatar": "https://some.url/avatar.jpg",
+      "country": "some-country",
+      "name": "John Doe",
+      "gender": "male",
+      "city": "some-city",
+      "age": 3e3
+    },
+    "email": "jd@example.com",
+    "phone_number": "55555",
+    "first_name": "John",
+    "last_name": "Doe"
+  }
+}

--- a/test/index.js
+++ b/test/index.js
@@ -68,6 +68,10 @@ describe('Outbound', function(){
       it('should map test for ios token ', function(){
         test.maps('identify-production');
       });
+
+      it('should map fallback on anonymousId if no userId ', function(){
+        test.maps('identify-anonymous');
+      });
     });
 
     describe('group', function(){


### PR DESCRIPTION
This allows outbound to fallback on `anonymousId` if `userId` does not exist. This is the current behavior of the [client side integration](https://github.com/segment-integrations/analytics.js-integration-outbound/blob/master/lib/index.js#L93) and thus we should keep that consistent on the server side.

@amnoonan 